### PR TITLE
chore: add codeowners and backstage catalog info

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @Multiverse-io/lobsters will be requested for
+# review when someone opens a pull request.
+
+*       @Multiverse-io/lobsters

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: amazon-ecs-deploy-task-definition
+  description: Github action to (only) deploy Amazon ECS task definitions. fork of https://github.com/aws-actions/amazon-ecs-deploy-task-definition
+  annotations:
+    github.com/project-slug: Multiverse-io/amazon-ecs-deploy-task-definition
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - javascript
+    - github-actions
+  links:
+    - title: GitHub
+      url: https://github.com/Multiverse-io/amazon-ecs-deploy-task-definition
+spec:
+  type: library
+  owner: lobsters
+  lifecycle: production


### PR DESCRIPTION
Adds CODEOWNERS and catalog-info.yaml file for Backstage marking Lobsters as the owners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Administrative metadata only (review ownership and catalog registration) with no runtime or production behavior changes.
> 
> **Overview**
> Adds a `CODEOWNERS` file to make `@Multiverse-io/lobsters` the default reviewers for changes across the repository.
> 
> Adds `catalog-info.yaml` to register this repo as a Backstage component (including ownership, lifecycle, tags, and TechDocs reference).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac94553922193e4228dfdd61f75ac0c06d74304e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->