### PR TITLE
Add base BugBot review rules scaffold

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,16 @@
+# amazon-ecs-deploy-task-definition — Repo-Specific BugBot Rules
+
+> Org-wide rules are enforced via Cursor Team Rules.
+
+## GitHub Action
+
+- This is a GitHub Action for deploying ECS task definitions (forked from AWS). The action definition is in `action.yml` and the logic is in `index.js`.
+- The bundled `dist/index.js` must be rebuilt after any changes to `index.js` or dependencies. PRs that modify source but not `dist/` are incomplete.
+
+## Testing
+
+- Tests are in `index.test.js`. Run tests before committing changes to the action logic.
+
+## Change Management
+
+- This action is consumed by many repos' CI pipelines. Breaking changes to inputs/outputs in `action.yml` affect all consumers — document in `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

- Adds `.cursor/BUGBOT.md` with starter code review rules tailored to this repo's tech stack.
- These are base scaffolds — repo owners should review and customise the rules for their specific needs.
- BugBot will use these rules in addition to the org-wide team rules when reviewing PRs.

## What is this?

BugBot is Cursor's AI code reviewer. It reads `.cursor/BUGBOT.md` files to enforce repo-specific review standards. See the [BugBot Developer Handbook](https://multiverse-io.github.io/global-tech-docs/devex/bugbot/) for details.

## Next steps

- [ ] Review the generated rules — remove any that don't apply, add repo-specific ones
- [ ] Consider adding nested `.cursor/BUGBOT.md` files for distinct modules if needed