### PR TITLE
chore: transfer ownership to async-learning team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # @Multiverse-io/lobsters will be requested for
 # review when someone opens a pull request.
 
-*       @Multiverse-io/lobsters
+*       @Multiverse-io/async-learning @Multiverse-io/lobsters

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,5 +14,5 @@ metadata:
       url: https://github.com/Multiverse-io/amazon-ecs-deploy-task-definition
 spec:
   type: library
-  owner: lobsters
+  owner: async-learning
   lifecycle: production


### PR DESCRIPTION
## Summary

- Added `@Multiverse-io/async-learning` to `CODEOWNERS` alongside the existing `@Multiverse-io/lobsters` team
- Updated `catalog-info.yaml` owner from `lobsters` to `async-learning`

Part of the team ownership migration to async-learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CODEOWNERS and Backstage catalog metadata with no runtime or logic impact.
> 
> **Overview**
> Shifts repository ownership toward **`@Multiverse-io/async-learning`** by adding the team as a default reviewer in `CODEOWNERS` (alongside `@Multiverse-io/lobsters`).
> 
> Updates `catalog-info.yaml` to set the Backstage component `spec.owner` from `lobsters` to `async-learning`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e0dca7a91a0a54d42ce21700bcbe1b2a039711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->